### PR TITLE
Stop disabling JSON tab in CDA IGs

### DIFF
--- a/scripts/onLoad.cda.xslt
+++ b/scripts/onLoad.cda.xslt
@@ -19,10 +19,13 @@
     </xsl:copy>
   </xsl:template>
   <xsl:template name="addCDAParameters">
+    <!-- SD moved to re-enable the JSON tab for Logical Models:
+         https://confluence.hl7.org/display/SD/2023-10-19+Agenda+and+Minutes
+         To hide it in your IG, just set the excludejson parameter to true
     <xsl:call-template name="setParameter">
       <xsl:with-param name="code" select="'excludejson'"/>
       <xsl:with-param name="value" select="'true'"/>
-    </xsl:call-template>
+    </xsl:call-template> -->
     <xsl:call-template name="setParameter">
       <xsl:with-param name="code" select="'excludettl'"/>
       <xsl:with-param name="value" select="'true'"/>


### PR DESCRIPTION
Per SD discussion on https://confluence.hl7.org/display/SD/2023-10-19+Agenda+and+Minutes - removing the setting of "excludejson" parameter to true in CDA templates.