### PR TITLE
Run schematron generator during onCheck phase

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,7 @@
 {
 	"script": "scripts/ant-cda.xml",
-	"otherScripts" : []
+	"otherScripts" : [],
+	"targets": {
+		"onCheck": "onCheck"
+	}
 }

--- a/scripts/ant-cda.xml
+++ b/scripts/ant-cda.xml
@@ -10,4 +10,12 @@
       <param name="spreadsheetList" expression="${prop.spreadsheet.contents}"/>
     </xslt>
   </target>
+  <target name="onCheck">
+    <!-- Run the fhir-cda-schematron generator from https://www.npmjs.com/package/@hl7/fhir-cda-validation
+         If it is not installed, just fails silently. -->
+    <echo message="Generating Schematron"/>
+    <exec executable="fhir-cda" failifexecutionfails="false">
+      <arg value="."/>
+    </exec>
+  </target>
 </project>


### PR DESCRIPTION
Discussed during September WGM - seems to be working well locally.

Need to wait until https://www.npmjs.com/package/@hl7/fhir-cda-validation is installed in the publisher box, though this should just fail silently if the executable does not yet exist.